### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,6 @@
     "documentationUrl": "https://sprout.barrelstrengthdesign.com/docs/seo",
     "changelogUrl": "https://raw.githubusercontent.com/BarrelStrength/sprout-seo-solspace-calendar/master/CHANGELOG.md",
     "downloadUrl": "https://github.com/BarrelStrength/sprout-seo-solspace-calendar/archive/master.zip",
-    "class": "barrelstrength\\sproutseosolspacecalendar\\sproutseosolspacecalendar"
+    "class": "barrelstrength\\sproutseosolspacecalendar\\SproutSeoSolspaceCalendar"
   }
 }


### PR DESCRIPTION
Installs and works fine on local. Won't install on Digital Ocean. Fails with:

```
  [craft\composer\InvalidPluginException]
  Couldn't install barrelstrength/sprout-seo-solspace-calendar: Unable to determine the base path
```

Usually this is a capitalization issue. Updating the composer.json class reference to match the capitalization on the class.